### PR TITLE
fix comple error PluginUtils::outputLog on android.

### DIFF
--- a/protocols/platform/android/PluginUtils.cpp
+++ b/protocols/platform/android/PluginUtils.cpp
@@ -169,7 +169,7 @@ void PluginUtils::outputLog(const char* logTag, const char* pFormat, ...)
 	vsnprintf(buf, MAX_LOG_LEN, pFormat, args);
 	va_end(args);
 
-	__android_log_print(ANDROID_LOG_DEBUG, logTag,  buf);
+	__android_log_print(ANDROID_LOG_DEBUG, logTag, "%s", buf);
 }
 
 jobject PluginUtils::getJObjFromParam(PluginParam* param)


### PR DESCRIPTION
fix comple error PluginUtils::outputLog on android.

thanks.
