### PR TITLE
Warns if plugin class not instantiable

### DIFF
--- a/protocols/platform/ios/PluginFactory.mm
+++ b/protocols/platform/ios/PluginFactory.mm
@@ -75,7 +75,15 @@ PluginProtocol* PluginFactory::createPlugin(const char* name)
 	{
 		if (name == NULL || strlen(name) == 0) break;
 
-        NSString* className = [NSString stringWithUTF8String:name];
+		NSString* className = [NSString stringWithUTF8String:name];
+		Class theClass = NSClassFromString(className);
+		if (theClass == nil)
+		{
+			PluginUtilsIOS::outputLog("Unable to load class '%s'. Did you add the -ObjC linker flag?", name);
+			break;
+		}
+		id obj = [[theClass alloc] init];
+
         id obj = [[NSClassFromString(className) alloc] init];
         if (obj == nil) break;
 


### PR DESCRIPTION
The class returned from NSClassFromString is checked and a warning is produced if it is nil.
