### PR TITLE
Safeguard for plugin.PluginParam

### DIFF
--- a/jsbindings/script/jsb_pluginx.js
+++ b/jsbindings/script/jsb_pluginx.js
@@ -1,5 +1,6 @@
 plugin = plugin || {};
 
+plugin.PluginParam = plugin.PluginParam || {};
 plugin.PluginParam.ParamType = {};
 plugin.PluginParam.ParamType.TypeInt = 1;
 plugin.PluginParam.ParamType.TypeFloat = 2;


### PR DESCRIPTION
Adds a safeguard in case plugin.PluginParam is undefined.
