### PR TITLE
Safeguard for plugin object

### DIFF
--- a/jsbindings/script/jsb_pluginx.js
+++ b/jsbindings/script/jsb_pluginx.js
@@ -1,4 +1,4 @@
-plugin = plugin || {};
+var plugin = plugin || {PluginParam: {}, ProtocolAds: {}, ProtocolIAP: {}, ProtocolShare: {}, ProtocolSocial: {}, ProtocolUser: {}};
 
 plugin.PluginParam.ParamType = {};
 plugin.PluginParam.ParamType.TypeInt = 1;


### PR DESCRIPTION
On iOS and Android, without a safeguard runtime errors can occur, causing a black screen.

Without `var`:

```
JS: assets/jsb/jsb_pluginx.js:1:ReferenceError: plugin is not defined
```

Without `plugin.ProtocolAds`, et cetera:

```
JS: assets/jsb/jsb_pluginx.js:11:TypeError: plugin.ProtocolAds is undefined
```

This safeguard fixes the errors.
