### PR TITLE
Adds another safeguard

### DIFF
--- a/jsbindings/script/jsb_pluginx.js
+++ b/jsbindings/script/jsb_pluginx.js
@@ -1,4 +1,5 @@
 var plugin = plugin || {PluginParam: {}, ProtocolAds: {}, ProtocolIAP: {}, ProtocolShare: {}, ProtocolSocial: {}, ProtocolUser: {}};
+plugin.PluginParam = plugin.PluginParam || {};
 
 plugin.PluginParam.ParamType = {};
 plugin.PluginParam.ParamType.TypeInt = 1;


### PR DESCRIPTION
Adds a safeguard for `plugin.PluginParam` because it can be undefined.
