### PR TITLE
Fix ad placement on iOS 8

### DIFF
--- a/protocols/platform/ios/AdsWrapper.mm
+++ b/protocols/platform/ios/AdsWrapper.mm
@@ -79,7 +79,7 @@ using namespace cocos2d::plugin;
     CGSize viewSize = view.frame.size;
     CGPoint viewOrigin;
 
-    if (UIInterfaceOrientationIsLandscape(controller.interfaceOrientation)){
+    if ([[UIDevice currentDevice].systemVersion floatValue] < 8.0 && UIInterfaceOrientationIsLandscape(controller.interfaceOrientation)){
         CGFloat temp = rootSize.width;
         rootSize.width = rootSize.height;
         rootSize.height = temp;


### PR DESCRIPTION
On iOS 8 you don't need to swap size values when the orientation is landscape. This pull fixes ad placement on iOS 8.
