### PR TITLE
Fix ad placement when not building with Xcode 6

### DIFF
--- a/protocols/platform/ios/AdsWrapper.mm
+++ b/protocols/platform/ios/AdsWrapper.mm
@@ -66,6 +66,42 @@ using namespace cocos2d::plugin;
     }
 }
 
++ (NSString*)buildVersion
+{
+  NSString *SDKPlatformVersion = [[NSBundle mainBundle] infoDictionary][@"DTPlatformVersion"];
+  
+  if (SDKPlatformVersion) {
+    return SDKPlatformVersion;
+  }
+  
+  // adapted from http://stackoverflow.com/questions/25540140/can-one-determine-the-ios-sdk-version-used-to-build-a-binary-programmatically
+  // form character set of digits and punctuation
+  NSMutableCharacterSet *characterSet = [[NSCharacterSet decimalDigitCharacterSet] mutableCopy];
+  
+  [characterSet formUnionWithCharacterSet: [NSCharacterSet punctuationCharacterSet]];
+  
+  // get only those things in characterSet from the SDK name
+  NSString *SDKName = [[NSBundle mainBundle] infoDictionary][@"DTSDKName"];
+  NSArray *components = [[SDKName componentsSeparatedByCharactersInSet: [characterSet invertedSet]]
+                         filteredArrayUsingPredicate: [NSPredicate predicateWithFormat:@"length != 0"]];
+  
+  if([components count])  {
+    return components[0];
+  }
+  
+  return nil;
+}
+
++ (BOOL)wasBuiltForiOS8orLater
+{
+  return [[self buildVersion] compare:@"8.0"] != NSOrderedAscending;
+}
+
++ (BOOL)requireRotation
+{
+  return ![self wasBuiltForiOS8orLater] || ([[[UIDevice currentDevice] systemVersion] floatValue] < 8.0);
+}
+
 + (void) addAdView:(UIView*) view atPos:(AdsPosEnum) pos
 {
     UIViewController* controller = [AdsWrapper getCurrentRootViewController];
@@ -79,7 +115,7 @@ using namespace cocos2d::plugin;
     CGSize viewSize = view.frame.size;
     CGPoint viewOrigin;
 
-    if ([[UIDevice currentDevice].systemVersion floatValue] < 8.0 && UIInterfaceOrientationIsLandscape(controller.interfaceOrientation)){
+    if ([self requireRotation] && UIInterfaceOrientationIsLandscape(controller.interfaceOrientation)){
         CGFloat temp = rootSize.width;
         rootSize.width = rootSize.height;
         rootSize.height = temp;


### PR DESCRIPTION
The previous version of this fix, pull 59, introduced a problem when the app is built with versions of Xcode before 6. This new pull positions the ads correctly regardless of build SDK version.
