### PR TITLE
Fix setDebugMode: call in Obj-C plugin API

### DIFF
--- a/protocols/platform/ios/PluginProtocol.mm
+++ b/protocols/platform/ios/PluginProtocol.mm
@@ -25,6 +25,15 @@ THE SOFTWARE.
 #include "PluginUtilsIOS.h"
 #include "PluginOCMacros.h"
 
+
+@protocol OCPluginProtocol
+@optional
+- (void)setDebugMode:(BOOL)debug;
+- (NSString *)getPluginVersion;
+- (NSString *)getSDKVersion;
+@end
+
+
 namespace cocos2d { namespace plugin {
 
 PluginProtocol::~PluginProtocol()
@@ -42,8 +51,10 @@ std::string PluginProtocol::getPluginVersion()
         SEL selector = NSSelectorFromString(@"getPluginVersion");
         
         if ([pOCObj respondsToSelector:selector]) {
-            NSString* strRet = (NSString*)[pOCObj performSelector:selector];
-            verName = [strRet UTF8String];
+            NSString* strRet = [pOCObj getPluginVersion];
+            if (strRet) {
+                verName = [strRet UTF8String];
+            }
         } else {
             PluginUtilsIOS::outputLog("Can't find function 'getPluginVersion' in class '%s'", pData->className.c_str());
         }
@@ -64,8 +75,10 @@ std::string PluginProtocol::getSDKVersion()
         SEL selector = NSSelectorFromString(@"getSDKVersion");
 
         if ([pOCObj respondsToSelector:selector]) {
-            NSString* strRet = (NSString*)[pOCObj performSelector:selector];
-            verName = [strRet UTF8String];
+            NSString* strRet = [pOCObj getSDKVersion];
+            if (strRet) {
+                verName = [strRet UTF8String];
+            }
         } else {
             PluginUtilsIOS::outputLog("Can't find function 'getSDKVersion' in class '%s'", pData->className.c_str());
         }
@@ -78,8 +91,19 @@ std::string PluginProtocol::getSDKVersion()
 
 void PluginProtocol::setDebugMode(bool isDebugMode)
 {
-    NSNumber* bDebug = [NSNumber numberWithBool:isDebugMode];
-    PluginUtilsIOS::callOCFunctionWithName_oneParam(this, "setDebugMode", bDebug);
+    PluginOCData* pData = PluginUtilsIOS::getPluginOCData(this);
+    if (pData) {
+        id pOCObj = pData->obj;
+        SEL selector = NSSelectorFromString(@"setDebugMode:");
+
+        if ([pOCObj respondsToSelector:selector]) {
+            [pOCObj setDebugMode:(BOOL)isDebugMode];
+        } else {
+            PluginUtilsIOS::outputLog("Can't find function 'setDebugMode' in class '%s'", pData->className.c_str());
+        }
+    } else {
+        PluginUtilsIOS::outputLog("Plugin %s is not initialized", this->getPluginName());
+    }
 }
 
 void PluginProtocol::callFuncWithParam(const char* funcName, PluginParam* param, ...)

--- a/protocols/platform/ios/PluginProtocol.mm
+++ b/protocols/platform/ios/PluginProtocol.mm
@@ -48,7 +48,7 @@ std::string PluginProtocol::getPluginVersion()
             PluginUtilsIOS::outputLog("Can't find function 'getPluginVersion' in class '%s'", pData->className.c_str());
         }
     } else {
-        PluginUtilsIOS::outputLog("Plugin %p not right initilized", this);
+        PluginUtilsIOS::outputLog("Plugin %p is not initialized", this);
     }
     
     return verName;
@@ -70,7 +70,7 @@ std::string PluginProtocol::getSDKVersion()
             PluginUtilsIOS::outputLog("Can't find function 'getSDKVersion' in class '%s'", pData->className.c_str());
         }
     } else {
-        PluginUtilsIOS::outputLog("Plugin %s not right initilized", this->getPluginName());
+        PluginUtilsIOS::outputLog("Plugin %s is not initialized", this->getPluginName());
     }
 
     return verName;


### PR DESCRIPTION
This is intended to fix the oddity where setDebugMode: receives an NSNumber instead of a BOOL in spite of the plugin interface (in Obj-C) specifying a BOOL, resulting in pretty much all plugin code using setDebugMode being up to a coin-toss's chance as to whether debug mode is actually enabled (since it just results in a pointer being truncated to a bool, which could be either true or false in the end).

Also corrects some typos.

Should ideally close #36.
