### PR TITLE
Revise config.sh to not use hardcoded list of plugins. Also quote vars.

### DIFF
--- a/tools/config.sh
+++ b/tools/config.sh
@@ -1,30 +1,44 @@
-#define plugins array 
-export ALL_PLUGINS=("flurry" "umeng" \
-"alipay" "nd91" "googleplay" \
-"admob" \
-"twitter" "weibo" \
-"qh360" "uc" \
-"facebook" "facebookads")
+#!/bin/bash
+
+# get array of plugin names
+
+# set IFS to newline so spaces aren't treated as delimiters in array
+temp_ifs="$IFS"
+IFS=$'\n'
+
+script_path="$BASH_SOURCE"
+script_path="$(dirname "$script_path")"
+ALL_PLUGINS=(`cd "${script_path}/../plugins" && find -L . -type d -and -depth 1`)
+PLUGIN_NUM=${#ALL_PLUGINS[@]}
+for ((i=0; i < ${PLUGIN_NUM}; i++))
+do
+    plugin_name="${ALL_PLUGINS[$i]}"
+    ALL_PLUGINS[$i]="${plugin_name#./}"
+done
+
+export ALL_PLUGINS
+echo "ALL_PLUGINS = (${ALL_PLUGINS[@]})"
+
+# restore IFS
+IFS="$temp_ifs"
+unset temp_ifs
 
 # define the plugin root directory & publish target directory
 export TARGET_DIR_NAME="publish"
 if [ ! ${PLUGIN_ROOT} ]; then
     pushd ../
-    export PLUGIN_ROOT=`pwd`
+    export PLUGIN_ROOT="$(pwd)"
     popd
 fi
-export TARGET_ROOT=${PLUGIN_ROOT}/${TARGET_DIR_NAME}
-echo PLUGIN_ROOT = ${PLUGIN_ROOT}
-echo TARGET_ROOT = ${TARGET_ROOT}
+export TARGET_ROOT="${PLUGIN_ROOT}/${TARGET_DIR_NAME}"
+echo "PLUGIN_ROOT = ${PLUGIN_ROOT}"
+echo "TARGET_ROOT = ${TARGET_ROOT}"
 
 # get a string include all plugins name(separate with ':')
 export PLUGINS_CAN_SELECT=""
-PLUGIN_NUM=${#ALL_PLUGINS[@]}
-for ((i=0; i<${PLUGIN_NUM}; i++))
+for ((i=0; i < ${PLUGIN_NUM}; i++))
 do
-    plugin_name=${ALL_PLUGINS[$i]}
-    PLUGINS_CAN_SELECT=${PLUGINS_CAN_SELECT}${plugin_name}
-    if [ $i -ne $((${PLUGIN_NUM}-1)) ]; then
-        PLUGINS_CAN_SELECT=${PLUGINS_CAN_SELECT}":"
-    fi
+    plugin_name="${ALL_PLUGINS[$i]}"
+    PLUGINS_CAN_SELECT="${PLUGINS_CAN_SELECT}${PLUGINS_CAN_SELECT:+:}${plugin_name}"
 done
+echo "PLUGINS_CAN_SELECT = ${PLUGINS_CAN_SELECT}"


### PR DESCRIPTION
Previous plugin list was hardcoded, which makes it difficult to do
plugin development, as it requires third-party plugin developers to
know to modify this script.

Instead, get the plugin source list using find, locating directories
(symlinks permitted).

Spaces in plugin names are handled appropriately, assuming you're
using bash 3.2-ish.

Additionally, variables, echos, etc. are mostly quoted now to avoid
odd cases where a space in a name might be treated as a command
invocation.
