### PR TITLE
issue #10186:setSDKVersion of facebookagent would trigger crash on the iOS platform

### DIFF
--- a/plugins/facebook/proj.ios/PluginFacebook/ShareFacebook.m
+++ b/plugins/facebook/proj.ios/PluginFacebook/ShareFacebook.m
@@ -179,7 +179,7 @@
 }
 
 - (void) setSDKVersion: (NSString *)sdkVersion{
-     [FBSettings setsdkVersion:sdkVersion];
+     [FBSettings setSDKVersion:sdkVersion];
 }
 
 - (NSString*) getPluginVersion

--- a/plugins/facebook/proj.ios/PluginFacebook/UserFacebook.m
+++ b/plugins/facebook/proj.ios/PluginFacebook/UserFacebook.m
@@ -99,7 +99,7 @@ NSString *_accessToken = @"";
     return [FBSettings sdkVersion];
 }
 - (void) setSDKVersion: (NSString *)sdkVersion{
-    [FBSettings setsdkVersion:sdkVersion];
+    [FBSettings setSDKVersion:sdkVersion];
 }
 - (NSString*) getPluginVersion{
     return @"";

--- a/plugins/facebook/proj.ios/sdk/FacebookSDK.framework/Versions/A/DeprecatedHeaders/FBSettings.h
+++ b/plugins/facebook/proj.ios/sdk/FacebookSDK.framework/Versions/A/DeprecatedHeaders/FBSettings.h
@@ -97,7 +97,7 @@ typedef NS_ENUM(NSUInteger, FBRestrictedTreatment) {
  @abstract Retrieve the current iOS SDK version.
  
  */
-+ (void)setsdkVersion:(NSString*)version;
++ (void)setSDKVersion:(NSString*)version;
 
 /*!
  @method

--- a/plugins/facebook/proj.ios/sdk/FacebookSDK.framework/Versions/A/Headers/FBSettings.h
+++ b/plugins/facebook/proj.ios/sdk/FacebookSDK.framework/Versions/A/Headers/FBSettings.h
@@ -97,7 +97,7 @@ typedef NS_ENUM(NSUInteger, FBRestrictedTreatment) {
  @abstract Retrieve the current iOS SDK version.
  
  */
-+ (void)setsdkVersion:(NSString*)version;
++ (void)setSDKVersion:(NSString*)version;
 
 /*!
  @method


### PR DESCRIPTION
This pr was fix the #10186, modify the implement of the setSDKVersion and adjust the api name.
