### PR TITLE
Remove AppDelegate memory leak in Android projects

### DIFF
--- a/samples/HelloPlugins/proj.android/jni/hellocpp/main.cpp
+++ b/samples/HelloPlugins/proj.android/jni/hellocpp/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -8,9 +10,13 @@
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
     JavaVM* vm;
     env->GetJavaVM(&vm);
     cocos2d::PluginJniHelper::setJavaVM(vm);

--- a/samples/HelloPlugins/proj.android/jni/hellocpp/main.cpp
+++ b/samples/HelloPlugins/proj.android/jni/hellocpp/main.cpp
@@ -1,19 +1,17 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
-#include "PluginJniHelper.h"
+#include <jni.h>
+
+#include "platform/android/PluginJniHelper.h"
+
+#include "AppDelegate.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
-using namespace cocos2d;
-
-void cocos_android_app_init (JNIEnv* env, jobject thiz) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
     JavaVM* vm;
     env->GetJavaVM(&vm);
-    PluginJniHelper::setJavaVM(vm);
+    cocos2d::PluginJniHelper::setJavaVM(vm);
 }

--- a/samples/HelloPluginsLua/frameworks/runtime-src/proj.android/jni/lua/main.cpp
+++ b/samples/HelloPluginsLua/frameworks/runtime-src/proj.android/jni/lua/main.cpp
@@ -1,17 +1,17 @@
-#include "AppDelegate.h"
-#include "cocos2d.h"
-#include "platform/android/jni/JniHelper.h"
-#include <jni.h>
 #include <android/log.h>
+#include <jni.h>
+
+#include "platform/android/PluginJniHelper.h"
+
+#include "AppDelegate.h"
 #include "ConfigParser.h"
-#include "PluginJniHelper.h"
 
 #define  LOG_TAG    "main"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
 
 using namespace cocos2d;
 
-void cocos_android_app_init (JNIEnv* env, jobject thiz) {
+void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
     AppDelegate *pAppDelegate = new AppDelegate();
     JavaVM* vm;
@@ -19,24 +19,24 @@ void cocos_android_app_init (JNIEnv* env, jobject thiz) {
     PluginJniHelper::setJavaVM(vm);
 }
 
+
 extern "C"
 {
-	bool Java_org_cocos2dx_HelloPluginsLua_AppActivity_nativeIsLandScape(JNIEnv *env, jobject thisz)
-	{
-		if (!ConfigParser::getInstance()->isInit())
-		{
-			ConfigParser::getInstance()->readConfig();
-		}
-		return ConfigParser::getInstance()->isLanscape();
-	}
+    bool Java_org_cocos2dx_HelloPluginsLua_AppActivity_nativeIsLandScape(JNIEnv *env, jobject thisz)
+    {
+        if (!ConfigParser::getInstance()->isInit())
+        {
+            ConfigParser::getInstance()->readConfig();
+        }
+        return ConfigParser::getInstance()->isLanscape();
+    }
 
-	bool Java_org_cocos2dx_HelloPluginsLua_AppActivity_nativeIsDebug(JNIEnv *env, jobject thisz)
-	{
-		#ifdef NDEBUG 
-    		return false;
-    	#else
-    		return true;	
-		#endif
-	}
+    bool Java_org_cocos2dx_HelloPluginsLua_AppActivity_nativeIsDebug(JNIEnv *env, jobject thisz)
+    {
+        #ifdef NDEBUG
+            return false;
+        #else
+            return true;
+        #endif
+    }
 }
-

--- a/samples/HelloPluginsLua/frameworks/runtime-src/proj.android/jni/lua/main.cpp
+++ b/samples/HelloPluginsLua/frameworks/runtime-src/proj.android/jni/lua/main.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <android/log.h>
 #include <jni.h>
 
@@ -11,9 +13,13 @@
 
 using namespace cocos2d;
 
+namespace {
+std::unique_ptr<AppDelegate> appDelegate;
+}
+
 void cocos_android_app_init(JNIEnv* env) {
     LOGD("cocos_android_app_init");
-    AppDelegate *pAppDelegate = new AppDelegate();
+    appDelegate.reset(new AppDelegate());
     JavaVM* vm;
     env->GetJavaVM(&vm);
     PluginJniHelper::setJavaVM(vm);


### PR DESCRIPTION
AppDelegate object and all its members are never released.
As a solution, I proposed to use static `unique_ptr` that could destroy it at the end of the application.

Before applying the aforementioned fix I corrected also code style and correctness of `main.cpp` files in Android projects:
- removed unused includes (reducing dependencies and compilation time)
- corrected code style (whitespaces, headers' order, etc).
