### PR TITLE
Performance tweak: use range-based for loops instead

### DIFF
--- a/protocols/platform/android/AgentManager.cpp
+++ b/protocols/platform/android/AgentManager.cpp
@@ -84,32 +84,32 @@ bool AgentManager::init(std::map<std::string, std::string>& conf)
 	if(conf.empty())
 		return false;
 
-	for(std::map<std::string, std::string>::iterator iter = conf.begin(); iter != conf.end(); ++iter)
+	for(auto& plugin : conf)
 	{
-		std::string pluginName = iter->first;
+		std::string pluginName = plugin.first;
 		if("PluginUser" == pluginName)
 		{
-			pUser = dynamic_cast<ProtocolUser *>(PluginManager::getInstance()->loadPlugin(iter->second.c_str()));
+			pUser = dynamic_cast<ProtocolUser *>(PluginManager::getInstance()->loadPlugin(plugin.second.c_str()));
 		}
 		else if("PluginShare" == pluginName)
 		{
-			pShare = dynamic_cast<ProtocolShare *>(PluginManager::getInstance()->loadPlugin(iter->second.c_str()));
+			pShare = dynamic_cast<ProtocolShare *>(PluginManager::getInstance()->loadPlugin(plugin.second.c_str()));
 		}
 		else if("PluginSocial" == pluginName)
 		{
-			pSocial = dynamic_cast<ProtocolSocial *>(PluginManager::getInstance()->loadPlugin(iter->second.c_str()));
+			pSocial = dynamic_cast<ProtocolSocial *>(PluginManager::getInstance()->loadPlugin(plugin.second.c_str()));
 		}
 		else if("PluginAds" == pluginName)
 		{
-			pAds = dynamic_cast<ProtocolAds *>(PluginManager::getInstance()->loadPlugin(iter->second.c_str()));
+			pAds = dynamic_cast<ProtocolAds *>(PluginManager::getInstance()->loadPlugin(plugin.second.c_str()));
 		}
 		else if("PluginAnalytics" == pluginName)
 		{
-			pAnalytics = dynamic_cast<ProtocolAnalytics *>(PluginManager::getInstance()->loadPlugin(iter->second.c_str()));
+			pAnalytics = dynamic_cast<ProtocolAnalytics *>(PluginManager::getInstance()->loadPlugin(plugin.second.c_str()));
 		}
 		else if("PluginIAP" == pluginName)
 		{
-			pIAP = dynamic_cast<ProtocolIAP *>(PluginManager::getInstance()->loadPlugin(iter->second.c_str()));
+			pIAP = dynamic_cast<ProtocolIAP *>(PluginManager::getInstance()->loadPlugin(plugin.second.c_str()));
 		}
 	}
 
@@ -135,13 +135,13 @@ std::map<std::string, std::string> AgentManager::getPluginConfigure()
 			jstring jValue;
 			std::string stdValue;
 
-			for(std::vector<std::string>::iterator iter = s_plugins.begin(); iter != s_plugins.end(); ++iter)
+			for(auto& plugin : s_plugins)
 			{
-				jKey = env->NewStringUTF((*iter).c_str());
+				jKey = env->NewStringUTF(plugin.c_str());
 				jValue = (jstring) (env->CallObjectMethod(jhashtable,tGetMethod.methodID,jKey));
 				stdValue = PluginJniHelper::jstring2string(jValue);
 				if(!stdValue.empty())
-					configure.insert(std::make_pair(*iter, stdValue));
+					configure.insert(std::make_pair(plugin, stdValue));
 			}
 
 			tGetMethod.env->DeleteLocalRef(jKey);

--- a/protocols/platform/android/PluginUtils.cpp
+++ b/protocols/platform/android/PluginUtils.cpp
@@ -56,10 +56,10 @@ jobject PluginUtils::createJavaMapObject(std::map<std::string, std::string>* par
 	if (paramMap != NULL)
 	{
 		jmethodID add_method= env->GetMethodID( class_Hashtable,"put","(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
-		for (std::map<std::string, std::string>::const_iterator it = paramMap->begin(); it != paramMap->end(); ++it)
+		for (const auto& parameter : *paramMap)
 		{
-            jstring first = env->NewStringUTF(it->first.c_str());
-            jstring second = env->NewStringUTF(it->second.c_str());
+            jstring first = env->NewStringUTF(parameter.first.c_str());
+            jstring second = env->NewStringUTF(parameter.second.c_str());
 			env->CallObjectMethod(obj_Map, add_method, first, second);
             env->DeleteLocalRef(first);
             env->DeleteLocalRef(second);
@@ -219,15 +219,14 @@ jobject PluginUtils::getJObjFromParam(PluginParam* param)
             jmethodID mid = env->GetMethodID(cls,"<init>","()V");
             obj = env->NewObject(cls,mid);
             env->DeleteLocalRef(cls);
-            std::map<std::string, std::string>::iterator it;
             std::map<std::string, std::string> mapParam = param->getStrMapValue();
-            for (it = mapParam.begin(); it != mapParam.end(); it++)
+            for (auto& parameter : mapParam)
             {
                 PluginJniMethodInfo tInfo;
                 if (PluginJniHelper::getMethodInfo(tInfo, "org/json/JSONObject", "put", "(Ljava/lang/String;Ljava/lang/Object;)Lorg/json/JSONObject;"))
                 {
-                    jstring strKey = tInfo.env->NewStringUTF(it->first.c_str());
-                    jstring strValue = tInfo.env->NewStringUTF(it->second.c_str());
+                    jstring strKey = tInfo.env->NewStringUTF(parameter.first.c_str());
+                    jstring strValue = tInfo.env->NewStringUTF(parameter.second.c_str());
 
                     tInfo.env->CallObjectMethod(obj, tInfo.methodID, strKey, strValue);
                     tInfo.env->DeleteLocalRef(tInfo.classID);
@@ -244,15 +243,14 @@ jobject PluginUtils::getJObjFromParam(PluginParam* param)
 			jmethodID mid = env->GetMethodID(cls,"<init>","()V");
 			obj = env->NewObject(cls,mid);
             env->DeleteLocalRef(cls);
-			std::map<std::string, PluginParam*>::iterator it;
 			std::map<std::string, PluginParam*> mapParam = param->getMapValue();
-			for (it = mapParam.begin(); it != mapParam.end(); it++)
+			for (auto& parameter : mapParam)
 			{
 				PluginJniMethodInfo tInfo;
 				if (PluginJniHelper::getMethodInfo(tInfo, "org/json/JSONObject", "put", "(Ljava/lang/String;Ljava/lang/Object;)Lorg/json/JSONObject;"))
 				{
-					jstring strKey = tInfo.env->NewStringUTF(it->first.c_str());
-					jobject objValue = PluginUtils::getJObjFromParam(it->second);
+					jstring strKey = tInfo.env->NewStringUTF(parameter.first.c_str());
+					jobject objValue = PluginUtils::getJObjFromParam(parameter.second);
 
 					tInfo.env->CallObjectMethod(obj, tInfo.methodID, strKey, objValue);
 					tInfo.env->DeleteLocalRef(tInfo.classID);


### PR DESCRIPTION
On my cocos2d-x git repository, `cppcheck` reported the following:

```
[plugin/protocols/platform/android/PluginUtils.cpp:224]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[plugin/protocols/platform/android/PluginUtils.cpp:249]: (performance) Prefer prefix ++/-- operators for non-primitive types.
```

This pull request mitigates those messages.