### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ One unified API for all SDKs
 * IAP
 * Social
 
-##Getting Started
+## Getting Started
 * [Try the sample](https://github.com/cocos2d-x/plugin-x/wiki/Sample)
 * [Documentation](http://www.cocos2d-x.org/wiki/Third_Party_SDK_Integration)
 * Check out [wiki](https://github.com/cocos2d-x/plugin-x/wiki) for more info
 
 
-##Update
+## Update
 * If you're looking for SDK integration solution for Chinese App Store, please consider using [AnySDK](http://www.anysdk.com) 

--- a/plugins/googleplay/Readme.md
+++ b/plugins/googleplay/Readme.md
@@ -24,7 +24,7 @@ For the to compile correctly you must do the following.
  ```
 
 
-##From Java
+## From Java
 ```java
 // This must be added to the new Cocos2dxActivity.java classes in cocos2d-x 3.0 + recently added
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
